### PR TITLE
bugfix: Exit with non-zero code when tests fail #13

### DIFF
--- a/cmd/httpprobe/run_cmd.go
+++ b/cmd/httpprobe/run_cmd.go
@@ -1,6 +1,8 @@
 package httpprobe
 
 import (
+	"os"
+
 	"github.com/mrfoh/httpprobe/internal/logging"
 	"github.com/mrfoh/httpprobe/internal/runner"
 	"github.com/mrfoh/httpprobe/internal/tests"
@@ -83,6 +85,16 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			testrunner.Write(results)
+
+			for _, defResult := range results {
+				for _, suiteResult := range defResult.Suites {
+					for _, caseResult := range suiteResult.Cases {
+						if !caseResult.Passed {
+							os.Exit(1)
+						}
+					}
+				}
+			}
 		},
 	}
 


### PR DESCRIPTION
Process now exits with code 1 if any test case fails, allowing CI pipelines to correctly detect test failures.
Closes: #13 