### PR TITLE
Implement variable type coercion for structured JSON bodies

### DIFF
--- a/docs/variable-interpolation.md
+++ b/docs/variable-interpolation.md
@@ -60,6 +60,52 @@ suites:
 
 Variables defined at the test definition level are available to all test suites, while suite-level variables are only available within that suite.
 
+## Variable Type Coercion
+
+By default, all variable values are treated as strings. If you need typed values in structured JSON request bodies (e.g. numbers or booleans instead of strings), you can set the `type` field to one of the supported types:
+
+| Type     | Description                  | Example Value |
+|----------|------------------------------|---------------|
+| `string` | Default, no conversion       | `"hello"`     |
+| `int`    | Coerced to integer           | `"42"`        |
+| `float`  | Coerced to floating point    | `"3.14"`      |
+| `bool`   | Coerced to boolean           | `"true"`      |
+
+Type coercion only applies when a structured JSON body field contains a single variable reference (e.g. `${count}`). Mixed strings like `"items_${count}"` are always treated as strings regardless of the variable's type.
+
+If the `type` field is omitted, the variable defaults to `string`, preserving backward compatibility.
+
+```yaml
+variables:
+  retries:
+    type: int
+    value: "3"
+  rate:
+    type: float
+    value: "1.5"
+  enabled:
+    type: bool
+    value: "true"
+  label:
+    type: string
+    value: "test-run"
+
+suites:
+  - name: Typed Variables Example
+    cases:
+      - title: Create resource
+        request:
+          method: POST
+          url: "https://api.example.com/resources"
+          body:
+            type: json
+            data:
+              retries: "${retries}"    # sent as 3 (integer)
+              rate: "${rate}"          # sent as 1.5 (float)
+              enabled: "${enabled}"    # sent as true (boolean)
+              label: "${label}"        # sent as "test-run" (string)
+```
+
 ## Using Environment Variables
 
 You can reference environment variables using the `${env:VAR_NAME}` syntax:

--- a/internal/tests/variables.go
+++ b/internal/tests/variables.go
@@ -138,10 +138,45 @@ func InterpolateVariables(input string, variables map[string]Variable) (string, 
 	return result, nil
 }
 
+// extractSoleVariableRef checks if a string is exactly a single variable reference
+// like "${count}" and returns the variable name. Returns false for mixed strings
+// like "prefix_${count}", env refs "${env:X}", or function calls "${random(5)}".
+func extractSoleVariableRef(s string) (string, bool) {
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") &&
+		strings.Count(s, "${") == 1 &&
+		!strings.HasPrefix(s, "${env:") &&
+		!strings.Contains(s, "(") {
+		return s[2 : len(s)-1], true
+	}
+	return "", false
+}
+
+// CoerceVariableValue converts a variable's string value to the appropriate Go type
+// based on the variable's Type field. Supported types: "int", "float", "bool".
+// If Type is empty or "string", the value is returned as-is.
+func CoerceVariableValue(variable Variable) (interface{}, error) {
+	switch variable.Type {
+	case "int":
+		return strconv.Atoi(variable.Value)
+	case "float":
+		return strconv.ParseFloat(variable.Value, 64)
+	case "bool":
+		return strconv.ParseBool(variable.Value)
+	default:
+		return variable.Value, nil
+	}
+}
+
 // InterpolateObject recursively interpolates variables in an object (map, slice, or scalar value)
 func InterpolateObject(obj interface{}, variables map[string]Variable) (interface{}, error) {
 	switch v := obj.(type) {
 	case string:
+		// If the entire string is a single variable reference, apply type coercion
+		if name, ok := extractSoleVariableRef(v); ok {
+			if variable, exists := variables[name]; exists {
+				return CoerceVariableValue(variable)
+			}
+		}
 		return InterpolateVariables(v, variables)
 	case map[string]interface{}:
 		result := make(map[string]interface{})

--- a/internal/tests/variables_test.go
+++ b/internal/tests/variables_test.go
@@ -169,6 +169,93 @@ func TestInterpolateVariableValues_UnresolvableReference(t *testing.T) {
 	}
 }
 
+func TestCoerceVariableValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		variable Variable
+		want     interface{}
+		wantErr  bool
+	}{
+		{"int", Variable{Type: "int", Value: "42"}, 42, false},
+		{"float", Variable{Type: "float", Value: "3.14"}, 3.14, false},
+		{"bool true", Variable{Type: "bool", Value: "true"}, true, false},
+		{"bool false", Variable{Type: "bool", Value: "false"}, false, false},
+		{"string", Variable{Type: "string", Value: "hello"}, "hello", false},
+		{"empty type", Variable{Type: "", Value: "hello"}, "hello", false},
+		{"invalid int", Variable{Type: "int", Value: "abc"}, 0, true},
+		{"invalid float", Variable{Type: "float", Value: "abc"}, 0.0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CoerceVariableValue(tt.variable)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CoerceVariableValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("CoerceVariableValue() = %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestInterpolateObject_TypedVariables(t *testing.T) {
+	variables := map[string]Variable{
+		"count":   {Type: "int", Value: "42"},
+		"rate":    {Type: "float", Value: "3.14"},
+		"active":  {Type: "bool", Value: "true"},
+		"name":    {Type: "string", Value: "John"},
+	}
+
+	obj := map[string]interface{}{
+		"count":  "${count}",
+		"rate":   "${rate}",
+		"active": "${active}",
+		"name":   "${name}",
+	}
+
+	result, err := InterpolateObject(obj, variables)
+	if err != nil {
+		t.Fatalf("InterpolateObject returned an error: %v", err)
+	}
+
+	m := result.(map[string]interface{})
+
+	if v, ok := m["count"].(int); !ok || v != 42 {
+		t.Errorf("count = %v (%T), want 42 (int)", m["count"], m["count"])
+	}
+	if v, ok := m["rate"].(float64); !ok || v != 3.14 {
+		t.Errorf("rate = %v (%T), want 3.14 (float64)", m["rate"], m["rate"])
+	}
+	if v, ok := m["active"].(bool); !ok || v != true {
+		t.Errorf("active = %v (%T), want true (bool)", m["active"], m["active"])
+	}
+	if v, ok := m["name"].(string); !ok || v != "John" {
+		t.Errorf("name = %v (%T), want John (string)", m["name"], m["name"])
+	}
+}
+
+func TestInterpolateObject_MixedStringNotCoerced(t *testing.T) {
+	variables := map[string]Variable{
+		"count": {Type: "int", Value: "42"},
+	}
+
+	obj := map[string]interface{}{
+		"label": "items_${count}",
+	}
+
+	result, err := InterpolateObject(obj, variables)
+	if err != nil {
+		t.Fatalf("InterpolateObject returned an error: %v", err)
+	}
+
+	m := result.(map[string]interface{})
+	if v, ok := m["label"].(string); !ok || v != "items_42" {
+		t.Errorf("label = %v (%T), want items_42 (string)", m["label"], m["label"])
+	}
+}
+
 func TestInterpolateRequest(t *testing.T) {
 	variables := map[string]Variable{
 		"api_url": {Type: "string", Value: "https://api.example.com"},


### PR DESCRIPTION
Add support for coercing variable types (int, float, bool) to native Go types when used in structured JSON request bodies.
Type coercion applies only to sole variable references, preserving backward compatibility by defaulting to string if the type is omitted.
Update documentation to reflect the new behavior and provide examples for clarity.

Fixes: #18