### PR TITLE
Enhance GraphQL assertions with variable interpolation, comparison operators, and length checks

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -197,7 +197,12 @@ Available GraphQL assertion options:
 | `partial_data` | `false` to fail if both `data` and `errors` coexist |
 | `data_schema` | JSON Schema to validate `response.data` against |
 
-Data paths use JSONPath expressions relative to `response.data`, so `$.user.id` refers to `response.data.user.id`. Regex patterns are supported by wrapping the expected value in forward slashes (`/pattern/`).
+Data paths use JSONPath expressions relative to `response.data`, so `$.user.id` refers to `response.data.user.id`. Data assertions support:
+
+- **Variable interpolation** — `"${user_id}"` resolves exported and defined variables
+- **Comparison operators** — `"> 5"`, `">= 10"`, `"contains error"` (same as body assertions)
+- **Regex patterns** — `"/.+@.+/"` (wrapped in forward slashes)
+- **Length checks** — `"length > 0"`, `"length 10"`, `"length <= 5"`
 
 For full details, see the [GraphQL Testing](graphql#graphql-assertions) page.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -155,7 +155,50 @@ graphql:
     "$.user.email": "/.+@.+/"    # Regex pattern matching
 ```
 
-Regex patterns are wrapped in forward slashes (`/pattern/`).
+#### Variable Interpolation in Assertions
+
+Exported variables and defined variables can be used in expected values:
+
+```yaml
+graphql:
+  data:
+    "$.user.id": "${user_id}"
+    "$.user.name": "${expected_name}"
+```
+
+#### Value Comparisons
+
+GraphQL data assertions support the same comparison operators as body assertions:
+
+```yaml
+graphql:
+  data:
+    # Equality (default)
+    "$.user.name": "Alice"
+
+    # Numeric comparisons
+    "$.user.age": "> 18"
+    "$.user.score": ">= 100"
+
+    # String contains
+    "$.user.email": "contains @example.com"
+
+    # Regex patterns (wrapped in forward slashes)
+    "$.user.email": "/.+@.+/"
+```
+
+#### Length Checks
+
+You can assert on the length of strings, arrays, and objects:
+
+```yaml
+graphql:
+  data:
+    "$.user.id": "length > 0"        # Non-empty string
+    "$.user.posts": "length > 0"     # Array with at least 1 item
+    "$.user.roles": "length 3"       # Exactly 3 items
+    "$.user.tags": "length <= 10"    # At most 10 items
+```
 
 ### errors
 

--- a/internal/reqassert/graphql.go
+++ b/internal/reqassert/graphql.go
@@ -74,8 +74,10 @@ func (a *GraphQLNoErrorsAssertion) Validate(ctx *AssertionContext) error {
 
 // GraphQLDataAssertion validates a JSONPath within response.data
 type GraphQLDataAssertion struct {
-	JSONPath      string
-	ExpectedValue interface{}
+	JSONPath       string
+	ExpectedValue  interface{}
+	ComparisonType string // equals, contains, gt, lt, etc.
+	IsLengthCheck  bool   // true when asserting on the length of the value
 }
 
 func (a *GraphQLDataAssertion) Validate(ctx *AssertionContext) error {
@@ -102,6 +104,29 @@ func (a *GraphQLDataAssertion) Validate(ctx *AssertionContext) error {
 		return fmt.Errorf("graphql data: error extracting '%s': %v", a.JSONPath, err)
 	}
 
+	// Handle length checks (e.g., "length > 0")
+	if a.IsLengthCheck {
+		var length int
+		switch v := actualValue.(type) {
+		case string:
+			length = len(v)
+		case []interface{}:
+			length = len(v)
+		case map[string]interface{}:
+			length = len(v)
+		default:
+			return fmt.Errorf("graphql data: '%s' cannot check length of %T", a.JSONPath, actualValue)
+		}
+		bodyAssertion := &BodyAssertion{
+			JSONPath:       a.JSONPath,
+			ComparisonType: a.ComparisonType,
+		}
+		if err := bodyAssertion.compareValues(float64(length), a.ExpectedValue); err != nil {
+			return fmt.Errorf("graphql data: '%s' length %d: %v", a.JSONPath, length, err)
+		}
+		return nil
+	}
+
 	// Check if expected value is a regex pattern (e.g., "/.+@.+/")
 	if expectedStr, ok := a.ExpectedValue.(string); ok {
 		if strings.HasPrefix(expectedStr, "/") && strings.HasSuffix(expectedStr, "/") && len(expectedStr) > 2 {
@@ -118,8 +143,14 @@ func (a *GraphQLDataAssertion) Validate(ctx *AssertionContext) error {
 		}
 	}
 
-	if actualValue != a.ExpectedValue {
-		return fmt.Errorf("graphql data: '%s' expected '%v', got '%v'", a.JSONPath, a.ExpectedValue, actualValue)
+	// Delegate to BodyAssertion for comparison operator support
+	bodyAssertion := &BodyAssertion{
+		JSONPath:       a.JSONPath,
+		ExpectedValue:  a.ExpectedValue,
+		ComparisonType: a.ComparisonType,
+	}
+	if err := bodyAssertion.compareValues(actualValue, a.ExpectedValue); err != nil {
+		return fmt.Errorf("graphql data: '%s' %v", a.JSONPath, err)
 	}
 	return nil
 }
@@ -277,9 +308,32 @@ func (f *GraphQLAssertionFactory) Create(key string, expected interface{}) (Asse
 	// data — JSONPath assertions relative to response.data
 	if data, ok := graphqlMap["data"].(map[string]interface{}); ok {
 		for jsonPath, expectedValue := range data {
+			comparisonType := ""
+			isLengthCheck := false
+			if expectedStr, ok := expectedValue.(string); ok {
+				// Check for "length" patterns first (e.g., "length > 0", "length 10")
+				lengthRe := regexp.MustCompile(`^\s*length\s*(=|==|!=|>|>=|<|<=)?\s*(\d+)\s*$`)
+				if matches := lengthRe.FindStringSubmatch(expectedStr); len(matches) > 0 {
+					isLengthCheck = true
+					comparisonType = matches[1]
+					if comparisonType == "" {
+						comparisonType = "="
+					}
+					expectedValue = matches[2]
+				} else {
+					// Parse comparison operators (same as BodyAssertionFactory)
+					re := regexp.MustCompile(`^\s*(=|==|!=|>|>=|<|<=|contains)\s*(.+)$`)
+					if matches := re.FindStringSubmatch(expectedStr); len(matches) > 0 {
+						comparisonType = matches[1]
+						expectedValue = matches[2]
+					}
+				}
+			}
 			group.Assertions = append(group.Assertions, &GraphQLDataAssertion{
-				JSONPath:      jsonPath,
-				ExpectedValue: expectedValue,
+				JSONPath:       jsonPath,
+				ExpectedValue:  expectedValue,
+				ComparisonType: comparisonType,
+				IsLengthCheck:  isLengthCheck,
 			})
 		}
 	}

--- a/internal/tests/suite.go
+++ b/internal/tests/suite.go
@@ -235,7 +235,7 @@ func (suite *TestSuite) ExecCase(testcase *TestCase, logger logging.Logger, clie
 	}
 
 	// Validate response using the new assertion framework
-	passed, validationErrors, err := validateWithAssertions(resp, testcase.Request.Assertions, logger)
+	passed, validationErrors, err := validateWithAssertions(resp, request.Assertions, logger)
 
 	elapsedTime := time.Since(startTime).Seconds()
 

--- a/internal/tests/variables.go
+++ b/internal/tests/variables.go
@@ -302,6 +302,17 @@ func InterpolateRequest(request *Request, variables map[string]Variable) error {
 		}
 	}
 
+	// Interpolate assertion expected values
+	if request.Assertions != nil {
+		interpolated, err := InterpolateObject(request.Assertions, variables)
+		if err != nil {
+			return fmt.Errorf("error interpolating assertions: %w", err)
+		}
+		if m, ok := interpolated.(map[string]interface{}); ok {
+			request.Assertions = m
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Introduce support for variable interpolation in expected values, add comparison operators for assertions, and implement length checks for strings, arrays, and maps in GraphQL data assertions. Update documentation to reflect these enhancements.